### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/java17-publish.yml
+++ b/.github/workflows/java17-publish.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  packages: write
 name: Publish JRE17 to the Maven Central
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/filip26/linked-tree/security/code-scanning/3](https://github.com/filip26/linked-tree/security/code-scanning/3)

To resolve the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly.

1. The workflow involves checking out code, setting up Java, importing a GPG key, and publishing a package using Maven. Based on these tasks, the minimal permissions would be:
   - `contents: read` (to access repository files during `checkout`).
   - `packages: write` (to publish packages to Maven Central).
2. The `permissions` block should be added at the root level of the workflow file to apply to all jobs, since there is only one job in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
