### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/java17-build.yml
+++ b/.github/workflows/java17-build.yml
@@ -3,6 +3,9 @@
 
 name: Java 17 PR CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/filip26/linked-tree/security/code-scanning/2](https://github.com/filip26/linked-tree/security/code-scanning/2)

To fix the issue:
1. Add a `permissions` block to the workflow at the root level (applies to all jobs) or within the `build` job specifically.
2. Use the least privilege required for the workflow's operations. Based on the provided steps, the workflow primarily reads the repository's contents (`contents: read`) and performs no write operations.
3. Modify the `.github/workflows/java17-build.yml` file to include the necessary permissions configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
