### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/java17-push.yml
+++ b/.github/workflows/java17-push.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 name: Java 17 CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/filip26/linked-tree/security/code-scanning/1](https://github.com/filip26/linked-tree/security/code-scanning/1)

To fix the issue, we will add a `permissions` key to the workflow file. Since the workflow only requires access to read the repository contents (e.g., to check out the code) and does not modify the repository, the `permissions` block should restrict access to `contents: read`. This will ensure that the workflow adheres to the principle of least privilege.

The change will be made at the root of the workflow file, directly under the `name` key, so that it applies to all jobs within the workflow. This avoids redundancy and simplifies the configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
